### PR TITLE
Add GO-CAM stats

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,3 +25,11 @@ This update affects statistics files starting August 2020.
 * detailed_changes.references.pmids.removed : detail the list of publications present in the previous release but not present in the new/current release
 
 Note: go-annotation-changes.tsv should also reflect those changes that primarily occurs in go-annotation-changes.json
+
+## Update September 2021
+
+This update affects statistics files starting October 2021.
+
+### go-stats, go-stats-no-pb, go-stats-summary and go-annotation-changes
+* gocams.all : the number of all GO-CAM models in RDF triplestore
+* gocams.causal : the number of all GO-CAM models having at least 3 activities connected through causal relationships in RDF triplestore

--- a/libraries/go-stats/go_annotation_changes.py
+++ b/libraries/go-stats/go_annotation_changes.py
@@ -195,6 +195,7 @@ def create_text_report(json_changes):
         text_report += "\nannotations by qualifier " + key + ":\t" + str(val)
     text_report += "\nreferences:\t" + str(json_changes["summary"]["current"]["references"])
     text_report += "\npmids:\t" + str(json_changes["summary"]["current"]["pmids"])
+    text_report += "\ngocams:\t" + str(json_changes["summary"]["current"]["gocams"])
 
     text_report += "\n\nSUMMARY: PREVIOUS RELEASE (" + json_changes["summary"]["previous"]["release_date"] + ")"
     text_report += "\nannotated bioentities:\t" + str(json_changes["summary"]["previous"]["bioentities"])
@@ -209,6 +210,7 @@ def create_text_report(json_changes):
         text_report += "\nannotations by qualifier " + key + ":\t" + str(val)
     text_report += "\nreferences:\t" + str(json_changes["summary"]["previous"]["references"])
     text_report += "\npmids:\t" + str(json_changes["summary"]["previous"]["pmids"])
+    text_report += "\ngocams:\t" + str(json_changes["summary"]["previous"]["gocams"])
 
     text_report += "\n\nSUMMARY: DIFF BETWEEN RELEASES"
     text_report += "\nannotated bioentities:\t" + str(json_changes["summary"]["current"]["bioentities"] - json_changes["summary"]["previous"]["bioentities"])

--- a/libraries/go-stats/go_annotation_changes.py
+++ b/libraries/go-stats/go_annotation_changes.py
@@ -90,7 +90,11 @@ def alter_annotation_changes(current_stats, previous_stats, current_references, 
                 "taxa" : current_stats["taxa"]["total"],
                 "taxa_filtered" : current_stats["taxa"]["filtered"],
                 "references" : current_stats["references"]["all"]["total"],
-                "pmids" : current_stats["references"]["pmids"]["total"]
+                "pmids" : current_stats["references"]["pmids"]["total"],
+                "gocams" : {
+                    "all" : current_stats["gocams"]["all"]["total"],
+                    "causal" : current_stats["gocams"]["causal"]["total"],
+                }
             },
             "previous" : {
                 "release_date" : previous_stats["release_date"],
@@ -104,7 +108,11 @@ def alter_annotation_changes(current_stats, previous_stats, current_references, 
                 "taxa" : previous_stats["taxa"]["total"],
                 "taxa_filtered" : previous_stats["taxa"]["filtered"],
                 "references" : previous_stats["references"]["all"]["total"],
-                "pmids" : previous_stats["references"]["pmids"]["total"]
+                "pmids" : previous_stats["references"]["pmids"]["total"],
+                "gocams" : {
+                    "all" : previous_stats["gocams"]["all"]["total"],
+                    "causal" : previous_stats["gocams"]["causal"]["total"],
+                }
             },
             "changes" : {
                 "annotations" : {
@@ -129,6 +137,10 @@ def alter_annotation_changes(current_stats, previous_stats, current_references, 
                     "total" : current_stats["references"]["pmids"]["total"] - previous_stats["references"]["pmids"]["total"],
                     "added" : 0,
                     "removed" : 0
+                },
+                "gocams" : {
+                    "all" : current_stats["gocams"]["all"]["total"] - previous_stats["gocams"]["all"]["total"],
+                    "causal" : current_stats["gocams"]["causal"]["total"] - previous_stats["gocams"]["causal"]["total"],
                 }
             },
         },
@@ -195,7 +207,8 @@ def create_text_report(json_changes):
         text_report += "\nannotations by qualifier " + key + ":\t" + str(val)
     text_report += "\nreferences:\t" + str(json_changes["summary"]["current"]["references"])
     text_report += "\npmids:\t" + str(json_changes["summary"]["current"]["pmids"])
-    text_report += "\ngocams:\t" + str(json_changes["summary"]["current"]["gocams"])
+    text_report += "\nall gocams:\t" + str(json_changes["summary"]["current"]["gocams"]["all"])
+    text_report += "\ncausal gocams:\t" + str(json_changes["summary"]["current"]["gocams"]["causal"])
 
     text_report += "\n\nSUMMARY: PREVIOUS RELEASE (" + json_changes["summary"]["previous"]["release_date"] + ")"
     text_report += "\nannotated bioentities:\t" + str(json_changes["summary"]["previous"]["bioentities"])
@@ -210,7 +223,8 @@ def create_text_report(json_changes):
         text_report += "\nannotations by qualifier " + key + ":\t" + str(val)
     text_report += "\nreferences:\t" + str(json_changes["summary"]["previous"]["references"])
     text_report += "\npmids:\t" + str(json_changes["summary"]["previous"]["pmids"])
-    text_report += "\ngocams:\t" + str(json_changes["summary"]["previous"]["gocams"])
+    text_report += "\nall gocams:\t" + str(json_changes["summary"]["previous"]["gocams"]["all"])
+    text_report += "\ncausal gocams:\t" + str(json_changes["summary"]["previous"]["gocams"]["causal"])
 
     text_report += "\n\nSUMMARY: DIFF BETWEEN RELEASES"
     text_report += "\nannotated bioentities:\t" + str(json_changes["summary"]["current"]["bioentities"] - json_changes["summary"]["previous"]["bioentities"])
@@ -231,6 +245,9 @@ def create_text_report(json_changes):
     
     for key, val in json_changes["summary"]["changes"]["pmids"].items():
         text_report += "\npmids " + key + ":\t" + str(json_changes["summary"]["changes"]["pmids"][key])
+
+    for key, val in json_changes["summary"]["changes"]["gocams"].items():
+        text_report += "\n" + key + " gocams:\t" + str(json_changes["summary"]["changes"]["gocams"][key])
 
 
 

--- a/libraries/go-stats/go_reports.py
+++ b/libraries/go-stats/go_reports.py
@@ -157,7 +157,8 @@ def main(argv):
         "annotations" : json_stats["annotations"],
         "taxa" : json_stats["taxa"],
         "bioentities" : json_stats["bioentities"],
-        "references" : json_stats["references"]
+        "references" : json_stats["references"],
+        "gocams" : json_stats["gocams"],
     }
     print("\n4a - SAVING GO-STATS...\n")
     utils.write_json(output_stats, json_stats)
@@ -170,7 +171,8 @@ def main(argv):
         "annotations" : json_stats_no_pb["annotations"],
         "taxa" : json_stats_no_pb["taxa"],
         "bioentities" : json_stats_no_pb["bioentities"],
-        "references" : json_stats_no_pb["references"]
+        "references" : json_stats_no_pb["references"],
+        "gocams": json_stats_no_pb["gocams"],
     }
     print("\n4b - SAVING GO-STATS-NO-PB...\n")
     utils.write_json(output_stats_no_pb, json_stats_no_pb)
@@ -272,6 +274,10 @@ def main(argv):
                 "removed" : json_annot_changes["summary"]["changes"]["pmids"]["removed"],
                 "by_model_organism" : pmids_by_reference_genome
             }
+        },
+        "gocams" : {
+            "all" : json_stats["gocams"]["all"]["total"],
+            "causal" : json_stats["gocams"]["causal"]["total"]
         },
     }
 

--- a/libraries/go-stats/go_stats_utils.py
+++ b/libraries/go-stats/go_stats_utils.py
@@ -1,5 +1,7 @@
 import json
 import requests
+import sparql_queries
+from SPARQLWrapper import SPARQLWrapper, JSON
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 from enum import Enum
@@ -113,7 +115,22 @@ def post(url, params):
     except Exception as x:
         print("Query POST " , url , " failed: ", x)
         return None
-    
+
+def sparql_fetch(blazegraph_url, query):
+    sparql = SPARQLWrapper(blazegraph_url)
+    sparql.setQuery(query)
+    sparql.setReturnFormat(JSON)
+    results = sparql.query().convert()
+    bindings = results['results']['bindings']
+    return bindings
+
+def sparql_gocams(blazegraph_url):
+    all_gocam_sparql_query = sparql_queries.ALL_GOCAM_MODELS
+    return sparql_fetch(blazegraph_url, all_gocam_sparql_query)
+
+def sparql_causal_gocams(blazegraph_url):
+    causal_gocam_sparql_query = sparql_queries.CAUSAL_GOCAM_MODELS
+    return sparql_fetch(blazegraph_url, causal_gocam_sparql_query)
 
 def golr_fetch(golr_base_url, select_query):
     """

--- a/libraries/go-stats/requirements.txt
+++ b/libraries/go-stats/requirements.txt
@@ -1,3 +1,3 @@
 requests==2.21.0
-networkx==1.11
+networkx==2.2
 SPARQLWrapper>=1.8.0

--- a/libraries/go-stats/requirements.txt
+++ b/libraries/go-stats/requirements.txt
@@ -1,2 +1,3 @@
 requests==2.21.0
 networkx==1.11
+SPARQLWrapper>=1.8.0

--- a/libraries/go-stats/setup.py
+++ b/libraries/go-stats/setup.py
@@ -15,7 +15,7 @@ setup(
     keywords=["GO", "Gene Ontology", "annotation", "ontology", "stats", "changes", "GOLR", "statistics"],
     install_requires=[
         'requests',
-        'networkx',
+        'networkx==2.2',
         'SPARQLWrapper'
     ],
 

--- a/libraries/go-stats/setup.py
+++ b/libraries/go-stats/setup.py
@@ -15,7 +15,8 @@ setup(
     keywords=["GO", "Gene Ontology", "annotation", "ontology", "stats", "changes", "GOLR", "statistics"],
     install_requires=[
         'requests',
-        'networkx'
+        'networkx',
+        'SPARQLWrapper'
     ],
 
     classifiers=[

--- a/libraries/go-stats/sparql_queries.py
+++ b/libraries/go-stats/sparql_queries.py
@@ -1,0 +1,95 @@
+CAUSAL_GOCAM_MODELS = """
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX pr: <http://purl.org/ontology/prv/core#>
+    PREFIX metago: <http://model.geneontology.org/>
+    PREFIX dc: <http://purl.org/dc/elements/1.1/>
+    PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> 
+    PREFIX obo: <http://www.geneontology.org/formats/oboInOwl#>
+    PREFIX owl: <http://www.w3.org/2002/07/owl#>
+    PREFIX providedBy: <http://purl.org/pav/providedBy>
+    
+    PREFIX MF: <http://purl.obolibrary.org/obo/GO_0003674>
+    
+    PREFIX causally_upstream_of_or_within: <http://purl.obolibrary.org/obo/RO_0002418>
+    PREFIX causally_upstream_of_or_within_negative_effect: <http://purl.obolibrary.org/obo/RO_0004046>
+    PREFIX causally_upstream_of_or_within_positive_effect: <http://purl.obolibrary.org/obo/RO_0004047>
+    
+    PREFIX causally_upstream_of: <http://purl.obolibrary.org/obo/RO_0002411>
+    PREFIX causally_upstream_of_negative_effect: <http://purl.obolibrary.org/obo/RO_0002305>
+    PREFIX causally_upstream_of_positive_effect: <http://purl.obolibrary.org/obo/RO_0002304>
+    
+    PREFIX regulates: <http://purl.obolibrary.org/obo/RO_0002211>
+    PREFIX negatively_regulates: <http://purl.obolibrary.org/obo/RO_0002212>
+    PREFIX positively_regulates: <http://purl.obolibrary.org/obo/RO_0002213>
+    
+    PREFIX directly_regulates: <http://purl.obolibrary.org/obo/RO_0002578>
+    PREFIX directly_positively_regulates: <http://purl.obolibrary.org/obo/RO_0002629>
+    PREFIX directly_negatively_regulates: <http://purl.obolibrary.org/obo/RO_0002630>
+    
+    PREFIX directly_activates: <http://purl.obolibrary.org/obo/RO_0002406>
+    PREFIX indirectly_activates: <http://purl.obolibrary.org/obo/RO_0002407>
+    
+    PREFIX directly_inhibits: <http://purl.obolibrary.org/obo/RO_0002408>
+    PREFIX indirectly_inhibits: <http://purl.obolibrary.org/obo/RO_0002409>
+    
+    PREFIX transitively_provides_input_for: <http://purl.obolibrary.org/obo/RO_0002414>
+    PREFIX immediately_causally_upstream_of: <http://purl.obolibrary.org/obo/RO_0002412>
+    PREFIX directly_provides_input_for: <http://purl.obolibrary.org/obo/RO_0002413>
+    PREFIX enabled_by: <http://purl.obolibrary.org/obo/RO_0002333>
+    
+    SELECT distinct ?gocam ?title
+    
+    WHERE 
+    {
+        VALUES ?causal { causally_upstream_of_or_within: causally_upstream_of_or_within_negative_effect: causally_upstream_of_or_within_positive_effect: 
+          causally_upstream_of: causally_upstream_of_negative_effect: causally_upstream_of_positive_effect: regulates: 				
+          negatively_regulates: positively_regulates: directly_regulates: directly_positively_regulates: directly_negatively_regulates:
+          directly_activates: indirectly_activates: directly_inhibits: indirectly_inhibits: transitively_provides_input_for: 
+          immediately_causally_upstream_of: directly_provides_input_for: }
+        
+        VALUES ?causal2 { causally_upstream_of_or_within: causally_upstream_of_or_within_negative_effect: causally_upstream_of_or_within_positive_effect: 
+          causally_upstream_of: causally_upstream_of_negative_effect: causally_upstream_of_positive_effect: regulates: 				
+          negatively_regulates: positively_regulates: directly_regulates: directly_positively_regulates: directly_negatively_regulates:
+          directly_activates: indirectly_activates: directly_inhibits: indirectly_inhibits: transitively_provides_input_for: 
+          immediately_causally_upstream_of: directly_provides_input_for: }
+            
+        GRAPH ?gocam {
+            ?gocam metago:graphType metago:noctuaCam .    
+            ?s enabled_by: ?gpnode .    
+            ?gpnode rdf:type ?identifier .
+            ?gocam dc:title ?title .   
+            
+            ?ind1 ?causal ?ind2 .     
+            ?ind2 ?causal2 ?ind3 .
+            
+            ?ind1 enabled_by: ?gpnode1 .
+            ?ind2 enabled_by: ?gpnode2 .
+            ?ind3 enabled_by: ?gpnode3 .
+            
+            ?gpnode1 rdf:type ?gp1 .    
+            ?gpnode2 rdf:type ?gp2 .    
+            ?gpnode3 rdf:type ?gp3 .    
+        }
+        ?ind1 rdf:type MF: .
+        ?ind2 rdf:type MF: .
+        ?ind3 rdf:type MF:      
+    }
+    ORDER BY ?gocam
+"""
+
+ALL_GOCAM_MODELS = """
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX metago: <http://model.geneontology.org/>
+    PREFIX dc: <http://purl.org/dc/elements/1.1/>
+    
+    SELECT distinct ?gocam ?title
+    
+    WHERE 
+    {     
+        GRAPH ?gocam {
+            ?gocam metago:graphType metago:noctuaCam .
+            ?gocam dc:title ?title
+        }
+    }
+    ORDER BY ?gocam
+"""


### PR DESCRIPTION
For geneontology/go-site#1180.

Remaining issues to solve before merging:
1. Parameterize `blazegraph_url` for triplestore created in Jenkins context similar to `golrurl` param. Likely will be localhost-something? Tagging @kltm.
2. `networkx` error (shown below) was occuring when using `networkx==1.11` as previously specified in `requirements.txt`. I upped this to `2.2` to match version installed in Jenkins `go-stats` [stage](https://github.com/geneontology/pipeline/blob/c5efe1a8a63d3590fb4d3e708bc4f55ca353237c/Jenkinsfile#L929) and the error was fixed.
3. How to handle the new `gocams` fields not appearing in the previous `go-stats.json` accessed from curent.geneontology.org? On the first run with this change, this field being omitted will break `go-stats` in several places. We might need to coordinate merging this PR with the data being "updated" on [current](http://current.geneontology.org/release_stats/go-stats.json)?

The `networkx` error mentioned in point 2 above:
```
File "/Users/ebertdu/go/go-stats/libraries/go-stats/obo_parser.py", line 462, in get_term
    return self.obo_graph.nodes[query]['object']
TypeError: 'method' object is not subscriptable
```